### PR TITLE
CacheInterface.h: make CkCache.h an angled #include

### DIFF
--- a/CacheInterface.h
+++ b/CacheInterface.h
@@ -7,7 +7,7 @@
  *  cache for requesting off processor particle and node data.
  */
 
-#include "CkCache.h"
+#include <CkCache.h>
 #include "config.h"
 #include "gravity.h"
 #include "GenericTreeNode.h"


### PR DESCRIPTION
Needed for similar reason as described in commit @c9a512e: ChaNGa's
dependency generation assumes that CkCache.h is a local include, and here
the files _it_ includes (using quoted-style inclusion) were being listed without 
path in Makefile.dep.

Ran into an issue with this on Lonestar, when compiling with GCC 4.4.5.
