### PR TITLE
Makefile.in: corrected references to Makefile.dep (lives in SOURCE dir)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -236,7 +236,7 @@ ref-clean:
 	rm -f $(TARGET) Compute.o TreeWalk.o
 
 depends: $(SOURCE_DIR)/Makefile.dep
-$(BUILD_DIR)/Makefile.dep:
+$(SOURCE_DIR)/Makefile.dep:
 	FULLPATHS=""; for file in $(SRSC); do FULLPATHS="$(SOURCE_DIR)/$$file $$FULLPATHS"; done; \
 	$(CXX_DEPEND) $$FULLPATHS | while read i;do echo $$i| awk -F' ' '{for (i=1;i<NF;++i) print $$i" \\"}';echo;done|grep -v "$(CHARM_PATH)/bin" | grep -v "hashtable_mt.h" > $@
 
@@ -249,4 +249,4 @@ $(BUILD_DIR)/Makefile.dep:
 
 .PHONY: all docs dist clean depend test VERSION.new
 
-include Makefile.dep
+include $(SOURCE_DIR)/Makefile.dep


### PR DESCRIPTION
Here's another change related to out-of-source builds -- it's something else I missed in previous pull-requests from this branch.   There's a potential discussion here about whether or not Makefile.dep is really a "source" file, but we'll leave that for another commit.
